### PR TITLE
Fix form page layout: add missing CSS for swipeable 3-panel slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -572,6 +572,323 @@ button { cursor: pointer; background: none; border: none; }
 body {
   background-attachment: fixed;
 }
+
+/* === FORM INPUTS === */
+.field-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+  font-family: var(--font-body);
+  color: var(--color-text);
+  background: rgba(44, 36, 32, 0.6);
+  border: 1px solid rgba(232, 88, 12, 0.2);
+  border-radius: var(--radius-md);
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.field-input::placeholder {
+  color: var(--color-text-faint);
+}
+
+.field-input:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(232, 88, 12, 0.15);
+}
+
+.field-input.error {
+  border-color: var(--color-error);
+  box-shadow: 0 0 0 3px rgba(217, 68, 68, 0.15);
+}
+
+.field-error {
+  display: none;
+  font-size: 0.8rem;
+  color: var(--color-error);
+  margin-top: 0.35rem;
+  font-weight: 500;
+}
+
+.field-error.visible {
+  display: block;
+}
+
+/* === SUBMIT BUTTON === */
+.submit-wrap {
+  margin-top: 0.5rem;
+}
+
+.submit-btn {
+  width: 100%;
+  padding: 1rem 2rem;
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  letter-spacing: 0.1em;
+  color: #fff;
+  background: var(--gradient-fire);
+  border: none;
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  box-shadow: 0 4px 16px rgba(232, 88, 12, 0.4);
+}
+
+.submit-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 24px rgba(232, 88, 12, 0.5);
+}
+
+.submit-btn:active {
+  transform: translateY(0);
+}
+
+.submit-btn.loading .btn-text {
+  visibility: hidden;
+}
+
+.submit-btn.loading .spinner {
+  display: block;
+}
+
+.spinner {
+  display: none;
+  width: 24px;
+  height: 24px;
+  border: 3px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin-top: -12px;
+  margin-left: -12px;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* === SUCCESS SCREEN === */
+.success-screen {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.5rem;
+  padding: 2rem;
+}
+
+.success-screen.show {
+  display: flex;
+}
+
+.success-icon {
+  width: 80px;
+  height: 80px;
+}
+
+.success-icon svg {
+  width: 100%;
+  height: 100%;
+  fill: none;
+  stroke: var(--color-success);
+  stroke-width: 2;
+}
+
+.success-check {
+  stroke-dasharray: 30;
+  stroke-dashoffset: 30;
+  animation: check-draw 0.5s ease forwards 0.2s;
+}
+
+@keyframes check-draw {
+  to { stroke-dashoffset: 0; }
+}
+
+.success-title {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  color: #fff;
+  letter-spacing: 0.04em;
+}
+
+.success-subtitle {
+  color: var(--color-text-muted);
+  font-size: var(--text-base);
+  max-width: 400px;
+}
+
+.reset-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-primary);
+  background: rgba(232, 88, 12, 0.1);
+  border: 1px solid rgba(232, 88, 12, 0.3);
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.reset-btn:hover {
+  background: rgba(232, 88, 12, 0.2);
+  border-color: var(--color-primary);
+}
+
+/* === EMBERS === */
+.ember {
+  position: fixed;
+  bottom: -20px;
+  background: radial-gradient(circle, rgba(232, 88, 12, 0.9), rgba(232, 88, 12, 0));
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 0;
+  animation: ember-rise linear forwards;
+}
+
+@keyframes ember-rise {
+  0% { bottom: -20px; opacity: 0.8; }
+  100% { bottom: 110vh; opacity: 0; }
+}
+
+/* === CONFETTI CANVAS === */
+#confetti-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 200;
+}
+
+/* === SLIDER LAYOUT === */
+.slider-container {
+  display: flex;
+  width: 300vw;
+  height: 100dvh;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  position: relative;
+  z-index: 1;
+}
+
+.slider-container::-webkit-scrollbar {
+  display: none;
+}
+
+.panel {
+  flex: 0 0 100vw;
+  width: 100vw;
+  height: 100dvh;
+  overflow-y: auto;
+  scroll-snap-align: start;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+/* === NAVIGATION DOTS === */
+.nav-dots {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 0.75rem;
+  z-index: 100;
+  padding: 0.5rem 1rem;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-radius: var(--radius-full);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.nav-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.25);
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.nav-dot.active {
+  background: var(--color-primary);
+  box-shadow: 0 0 8px rgba(232, 88, 12, 0.6);
+  transform: scale(1.2);
+}
+
+.nav-dot:hover:not(.active) {
+  background: rgba(255, 255, 255, 0.5);
+}
+
+/* === NAVIGATION ARROWS === */
+.nav-arrow {
+  position: fixed;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 100;
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.5);
+  background: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 50%;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.nav-arrow:hover {
+  color: #fff;
+  background: rgba(232, 88, 12, 0.4);
+  border-color: rgba(232, 88, 12, 0.5);
+}
+
+.nav-left {
+  left: 1rem;
+}
+
+.nav-right {
+  right: 1rem;
+}
+
+/* === FOOTER === */
+.site-footer {
+  display: none;
+}
+
+.footer-brand {
+  position: fixed;
+  bottom: 4rem;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.75rem;
+  color: var(--color-text-faint);
+  white-space: nowrap;
+  z-index: 99;
+  pointer-events: none;
+}
 </style>
 </head>
 <body>


### PR DESCRIPTION
The slider container, panel, nav dots, nav arrows, form inputs, submit button, success screen, and ember styles were all missing from the CSS, causing everything to render as one tall column with unstyled HTML inputs.

This adds all the missing base styles so the page loads on the center form panel and supports swiping left (info/about) and right (beer list).

https://claude.ai/code/session_01FEeKFzSaVD66TyU6GYfqzu