### PR TITLE
docs: add 4/9/26 meeting data

### DIFF
--- a/docs/meeting-data-2026-04-09.md
+++ b/docs/meeting-data-2026-04-09.md
@@ -1,0 +1,23 @@
+# Meeting Data — April 9, 2026
+
+## Referrals
+
+| # | Referral Giver | Referral Recipient | Referral Is | Member? | Special Notes |
+|---|---|---|---|---|---|
+| 1 | Mark Bougen | Dawn | 212 Work Hard Therapy | — | — |
+| 2 | Dana Strauss | Dana Walsh | Do the Dew Plumbing — 919-659-5520 | Member | Jennifer is the person to talk to; Fire Spoken Hutch is the owner |
+| 3 | Dana Walsh | Shannida Ramsey | Denise Stewart — 954-220-2630 | Member | — |
+| 4 | Rusty Sutton | Charissa Rolof | ME Broadcasting LLC | — | — |
+| 5 | Dana Walsh | Sue Kerata | Label & Page Manufacturing | Member | — |
+| 6 | Will Sigmon | Dana Walsh | Many Car Dealerships | Member | — |
+| 7 | Shannida Ramsey | Kristy | (unknown) Media — 901-930-5626 | — | "Desired our Business" |
+| 8 | Carter Helms | Will Sigmon | Donny Bells | Member | AT Coconut/Furniture |
+| 9 | Carter Helms | Donny Bells | Kate Griffin, Wedding Photography | — | Not in member directory — verify membership status |
+
+## GI & BizChat Tracking
+
+| Member | GIs Presented to Members | GIs Received from Members | GIs Received from Corporate | BizChats |
+|---|---|---|---|---|
+| Rusty Sutton | 2 | — | — | 3 |
+| Robert Courts | — | — | — | 5 |
+| Dana Walsh | — | — | — | 3 |


### PR DESCRIPTION
## Summary
- 9 referrals, 11 BizChats, 2 GIs from the April 9, 2026 meeting
- Names cross-referenced against member directory and corrected from handwritten card OCR

## Test plan
- [x] Format matches existing `meeting-data-2026-04-02.md`
- [x] Member names verified against `api/_lib/member-directory.js`