### PR TITLE
feat(aio): AI crawler allowlist in robots.txt + expanded llms.txt

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -11,6 +11,26 @@
 - Venue partner: Clouds Brewing Raleigh
 - Website: https://rduheatwave.team
 
+## What is the 212 Referral Network?
+212°F is the temperature at which water boils — one degree past 211. The "extra degree" philosophy holds that going one degree beyond transforms hot water into steam, and effort into results. 212 chapters are structured referral groups where local professionals exchange business referrals, track contribution, and build long-term relationships.
+
+## Key terminology
+- **Steam Score**: Aggregate member performance metric combining referrals given, referrals received, and meeting attendance.
+- **GI (Gratitude Incentive)**: Points earned for referral activity; the core gamification metric.
+- **BizChat**: A short one-on-one meeting between two members held outside the weekly meeting.
+- **Visitor**: A prospective member attending a meeting as a member's guest.
+
+## Weekly meeting structure
+1. Networking / open time
+2. Welcome and mentor moment
+3. Member introductions (30-second elevator pitches)
+4. Referral round — who has referrals to give?
+5. Guest introductions
+6. Closing
+
+## Visiting
+Prospective members are welcome to attend as a guest of an existing member. Meetings are held Wednesday mornings in the side room at Clouds Brewing, 1233 Front St, Raleigh, NC 27609. Start at the registration form on the home page to check in or express interest.
+
 ## Public pages
 - Home / Onboarding: https://rduheatwave.team/
 - Meeting Lobby: https://rduheatwave.team/meet

--- a/robots.txt
+++ b/robots.txt
@@ -12,4 +12,41 @@ Disallow: /survey
 Disallow: /survey-results
 Disallow: /report
 
+# AI assistants and search crawlers — welcome on public pages,
+# same private-page restrictions as everyone else
+User-agent: anthropic-ai
+User-agent: ClaudeBot
+User-agent: Claude-Web
+User-agent: Claude-User
+User-agent: Claude-SearchBot
+User-agent: GPTBot
+User-agent: OAI-SearchBot
+User-agent: ChatGPT-User
+User-agent: PerplexityBot
+User-agent: Perplexity-User
+User-agent: Google-Extended
+User-agent: Applebot-Extended
+User-agent: cohere-ai
+User-agent: meta-externalagent
+User-agent: DuckAssistBot
+Allow: /
+Disallow: /agenda
+Disallow: /admin
+Disallow: /api/
+Disallow: /crm
+Disallow: /remind
+Disallow: /kiosk
+Disallow: /timer
+Disallow: /bizchat
+Disallow: /survey
+Disallow: /survey-results
+Disallow: /report
+
+# Bulk scrapers not welcome
+User-agent: Bytespider
+Disallow: /
+
 Sitemap: https://rduheatwave.team/sitemap.xml
+
+# AI-readable site summary
+# https://rduheatwave.team/llms.txt


### PR DESCRIPTION
## What

Two AIO (AI Optimization) improvements flagged by the 2026-07-20 weekly SEO/AIO audit:

### robots.txt
- Adds an explicit allowlist group for AI assistant and AI search crawlers (anthropic-ai, ClaudeBot, Claude-Web/User/SearchBot, GPTBot, OAI-SearchBot, ChatGPT-User, PerplexityBot, Perplexity-User, Google-Extended, Applebot-Extended, cohere-ai, meta-externalagent, DuckAssistBot) with the same private-page `Disallow` rules as the wildcard group — public pages stay open, `/agenda`, `/admin`, `/api/`, `/crm`, etc. stay blocked.
- Blocks Bytespider (bulk scraper).
- Adds a comment pointing crawlers at `/llms.txt`.

### llms.txt
Expanded from fast-facts-only to a fuller AI-readable profile:
- "What is the 212 Referral Network?" explainer (the extra-degree philosophy)
- Key terminology definitions (Steam Score, GI points, BizChat, Visitor)
- Weekly meeting structure
- Visitor guidance (when/where, how to attend as a guest)

## Why

AI assistants (Claude, ChatGPT, Perplexity) are increasingly how people discover local groups. Without explicit allow rules some AI crawlers self-exclude, and the previous llms.txt didn't give an assistant enough context to answer "what is RDU HeatWave / how do I visit?" accurately. All facts are sourced from existing site content and project docs — nothing new invented.

No build step required; deploys as-is via Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBXzXGA6yJfMb5fieidTK7

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBXzXGA6yJfMb5fieidTK7)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static SEO/AIO text only; no runtime, auth, or data-handling changes.
> 
> **Overview**
> **AI discovery (AIO):** `robots.txt` now includes a dedicated crawler group for major AI assistants and search bots, with the same public allow and private-path `Disallow` list as the wildcard rule, plus a full block on **Bytespider** and a comment pointing to `/llms.txt`.
> 
> **`llms.txt`** grows beyond fast facts with a 212/extra-degree explainer, terminology (Steam Score, GI, BizChat, Visitor), weekly meeting flow, and guest visit instructions—content drawn from existing site/docs, no app code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc430789fed308aa8ff3f16da05fb6e6e363efa8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->